### PR TITLE
Make some particle numbers positive

### DIFF
--- a/scripts/alien_buildable_bleed.particle
+++ b/scripts/alien_buildable_bleed.particle
@@ -21,7 +21,7 @@ particles/buildables/alien_base/bleed
 
 			radius                0 5 8
 			alpha                 250 .85 0
-			rotation              0 ~-15 ~15
+			rotation              0 ~15 ~15
 			bounce                0
 			color                 0 { 1 1 .6 } -
 

--- a/scripts/human_buildable_bleed.particle
+++ b/scripts/human_buildable_bleed.particle
@@ -21,7 +21,7 @@ particles/buildables/human_base/bleed
 
 			radius                0 5 8
 			alpha                 250 .75 0
-			rotation              0 ~-15 ~15
+			rotation              0 ~15 ~15
 			bounce                0
 			color                 0 { .8 .2 .2 } -
 
@@ -47,7 +47,7 @@ particles/buildables/human_base/bleed
 
 			radius                0 5 8
 			alpha                 250 .75 0
-			rotation              0 ~-15 ~15
+			rotation              0 ~15 ~15
 			bounce                0
 			color                 0 { .8 .2 .2 } -
 


### PR DESCRIPTION
cgame expect these numbers to be positive as they are read with `atof_neg`, but they are positive here.

I don't know what this specific value does, so I just swapped the sign