### PR TITLE
material: creep is both diffuseMap and clampmap

### DIFF
--- a/scripts/creep.shader
+++ b/scripts/creep.shader
@@ -4,7 +4,8 @@ gfx/buildables/creep/creep
 	polygonoffset
 	twoSided
 	{
-		clampmap gfx/buildables/creep/creep_d
+		clamp
+		diffuseMap gfx/buildables/creep/creep_d
 		specularMap gfx/buildables/creep/creep_s
 		normalMap gfx/buildables/creep/creep_n
 		blendfunc blend


### PR DESCRIPTION
material: creep is both diffuseMap and clampmap

Before I fixed some bug in collapse code, the buggy code was mistakenly collapsing this buggy material as diffuseMap while not explictly calling for it, basically having a mistake in engine cancelling a mistake in material. This material should be both clampmap and diffusmap, but now that the bug wrongly implying diffusemap when it was not asked for is fixed, we need to ask for diffusemap explicitly, as it should alway have been.