### PR TITLE
gfx: use imageMinDimension on creep

### DIFF
--- a/scripts/creep.shader
+++ b/scripts/creep.shader
@@ -1,8 +1,8 @@
 gfx/buildables/creep/creep
 {
-	nopicmip
 	polygonoffset
 	twoSided
+	imageMinDimension 16
 	{
 		clamp
 		diffuseMap gfx/buildables/creep/creep_d


### PR DESCRIPTION
This can suffer some downscaling on low presets.