### PR TITLE
models: scale telenode model at build time

### DIFF
--- a/configs/buildables/telenode.model.cfg
+++ b/configs/buildables/telenode.model.cfg
@@ -1,6 +1,6 @@
 model       0 models/buildables/telenode/telenode.iqm
 modelRotation 0 180 0
-modelScale  0.9
+modelScale  1
 mins        -36 -36 -4
 maxs        36 36 13
 zOffset     -4

--- a/models/buildables/telenode/telenode.iqe.cfg
+++ b/models/buildables/telenode/telenode.iqe.cfg
@@ -1,4 +1,4 @@
 output models/buildables/telenode/telenode.iqm
 rotate 0 -180 0
-scale .7569
+scale 0.65
 scene models/buildables/telenode/telenode.iqe


### PR DESCRIPTION
Purpose is to fix Unvanquished/Unvanquished#2880:

- https://github.com/Unvanquished/Unvanquished/issues/2880

I don't know why Unvanquished/Unvanquished#2880 happens and there may be a bug that not everything is scaled up from `.model.cfg` file, but anyway we better want to scale the model itself so we can keep the default scale everywhere, and it will even be properly scaled in NetRadiant.